### PR TITLE
fix two links, Team player and Volunteer

### DIFF
--- a/app/views/welcome/homepage.html.erb
+++ b/app/views/welcome/homepage.html.erb
@@ -9,7 +9,7 @@
     <div class="card-body">
       <h5 class="card-title">Volunteer</h5>
       <p class="card-text">Are you a maintiance person, a skilled volunteer, or just someone with a welling heart. Please apply as a volunteer and become not just a part of the team, but also part of the family.</p>
-      <%= link_to "Become a Volunteer", volunteers_path %>
+      <%= link_to "Become a Volunteer", new_volunteer_path %>
     </div>
   </div>
   <div class="card">
@@ -17,7 +17,7 @@
     <div class="card-body">
       <h5 class="card-title">Team Member</h5>
       <p class="card-text">Learn more about us, how you can help and how you can become part of our team. </p><br/><br/>
-            <%= link_to "Team Player", volunteers_path %>
+            <%= link_to "Team Player", new_volunteer_path %>
     </div>
   </div>
   <div class="card">


### PR DESCRIPTION
Fix two links, The become a volunteers was taking you to the index volunteer instead of volunteer new where you can sign up to become one, Also fix Team player link, to also route you to sign up to become a volunteer, instead of the volunteer index.

@jrmcgarvey @leila-alderman 