### PR TITLE
Edit to Migration for Availability Rollback Error. Edited styling to …

### DIFF
--- a/app/views/owners/index.html.erb
+++ b/app/views/owners/index.html.erb
@@ -1,14 +1,36 @@
 <% if current_user.role == "admin" %>
+  <div>
   <%= render 'shared/staff_banner' %>
+  <%= render 'shared/admin_navbar' %>
+  </div>
+  <!--Admin role may not allow creation of volunteer and homeowner profiles or repairs,-->
+  <div class="row icons">
+    <div class="col-4">
+      <img src="http://casa-alameda.org/wp-content/uploads/2016/11/volunteer-icon-grey.png" height=40px>
+      <%= link_to 'Create Volunteer Profile', new_volunteer_path %>
+    </div>
+    <div class="col-4">
+      <img src='https://static.thenounproject.com/png/1663528-200.png' width=40px>
+      <%= link_to 'Create Homeowner Profile', new_owner_path %>
+    </div>
+    <div class="col-4">
+      <img src='http://golfcartrentalsorlando.com/wp-content/uploads/2015/01/repair-2.png' width=40px>
+      <%= link_to 'Create Repair', new_repair_path %>
+    </div>
+  </div> 
   <br>
   <h2 class="center">Homeowner's Index</h2>
   <p class="center"><i>Number of Homeowners (<%= @owners.count %>)</i></p>
-    <ul>
-      <% @owners.each do |owner| %>
-        <li><%= link_to owner.full_name, owner %> - <%= owner.short_address %></li>
-   <% end %>
-    </ul>
-<%= render 'shared/footer' %>
+  <% @owners.each do |owner| %>
+    <div class="row">
+      <div class="col-1"></div>
+      <div class="col">
+        <h4><%= link_to owner.full_name, owner %></h4> 
+        <i>,<%= owner.short_address %></i>
+      </div>
+    </div>
+  <% end %>
+<%#<%= render 'shared/footer' %>
 <% end %>
 
 <% if user_signed_in? && current_user.owner == nil%>

--- a/app/views/shared/_admin_navbar.html.erb
+++ b/app/views/shared/_admin_navbar.html.erb
@@ -1,0 +1,32 @@
+ <div>
+ <nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <%= link_to "Rebuilding Together", root_path, class: "navbar-brand" %>
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav mr-auto">
+      <li class="nav-item">
+        <%= link_to "Volunteers Index", volunteers_path,  class: "nav-link" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to "Homeowners Index", owners_path, class: "nav-link" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to "Repairs Index", repairs_path, class: "nav-link" %>
+      </li>
+  </div>
+  <div class="logout">
+     <ul class="nav navbar-nav navbar-right">
+      <% if current_user == nil %>
+       <li>
+        <%= link_to "Sign up", new_user_registration_path, class: "nav-link" %> <span class="sr-only">(current)</span>
+       </li>
+        <li>
+        <%= link_to "Login", new_user_session_path, class: "nav-link"  %> <span class="sr-only">(current)</span>
+       </li>
+       <% else %>
+       <li>
+        <%= link_to "Logout",  destroy_user_session_path, :method => "delete", class: "nav-link"  %> <span class="sr-only">(current)</span>
+       </li>
+       <% end %>
+      </ul>
+  </div>
+</nav>

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -1,7 +1,9 @@
 <div>
 <%= render 'shared/staff_banner' %>
-<%= render 'welcome/sans_logo_nav_bar' %>
+<%= render 'shared/admin_navbar' %>
 </div>
+
+<!--Admin role may not allow creation of volunteer and homeowner profiles or repairs,-->
 <div class="row icons">
   <div class="col-4">
     <img src="http://casa-alameda.org/wp-content/uploads/2016/11/volunteer-icon-grey.png" height=40px>

--- a/db/migrate/20190412181103_remove_availability_from_volunteers.rb
+++ b/db/migrate/20190412181103_remove_availability_from_volunteers.rb
@@ -1,5 +1,14 @@
 class RemoveAvailabilityFromVolunteers < ActiveRecord::Migration[5.2]
   def down
-    remove_column :volunteers, :availability
+    remove_column :volunteers, :availability, :string if availability_exists?
+  end
+  
+  def up
+    remove_column :volunteers, :availability, :string if availability_exists?
+  end
+  
+  private
+  def availability_exists?
+    column_exists?(:volunteers, :availability)
   end
 end

--- a/db/migrate/20190417015013_remove_availability_from_volunteers.rb
+++ b/db/migrate/20190417015013_remove_availability_from_volunteers.rb
@@ -1,9 +1,5 @@
 class RemoveAvailabilityFromVolunteers < ActiveRecord::Migration[5.2]
-  def down
-    remove_column :volunteers, :availability, :string if availability_exists?
-  end
-  
-  def up
+  def change
     remove_column :volunteers, :availability, :string if availability_exists?
   end
   

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,7 +77,6 @@ ActiveRecord::Schema.define(version: 2019_04_12_181326) do
     t.string "state"
     t.string "employer"
     t.string "position"
-    t.string "availability"
     t.string "skill"
     t.text "volunteer_notes"
     t.integer "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_12_181326) do
+ActiveRecord::Schema.define(version: 2019_04_17_015013) do
 
   create_table "owners", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
…include render for admin_navbar on index for owners and volunteers. Put list of owers in index in div class row, cols

@jrmcgarvey @leila-alderman 

I made an attempt to correct the error for the availability still showing. I read online that I should delete the development.sqlite3 file. I did this and I was allowed to do the rails db:reset and rails db:migrate. 

I added some code to the remove availability migration file that is supposed to help prevent it from causing an issue. If you think its not necessary let me know. 

I also worked on the nav bar for the index page for owners and volunteers. They're the same since I assume only the staff should be able to see them. 

Let me know if you have any questions,

Tilneil
